### PR TITLE
Fix speak.py to run optionally

### DIFF
--- a/speak.py
+++ b/speak.py
@@ -26,14 +26,17 @@ def speak_text(text: str, chunk_size: int = 50, delay: float = 0.1):
         time.sleep(delay)  # give the audio thread time to start
 
 if __name__ == "__main__":
+    if os.environ.get("RUN_SPEECH") != "1":
+        print("RUN_SPEECH=1 is required to run TTS demo.")
+        raise SystemExit(0)
     import patch_xtts
 
     multiprocessing.freeze_support()
 
     from RealtimeTTS import TextToAudioStream, CoquiEngine
 
-    # VITS model still works, but we won't stream it chunk-by-chunk:
-    engine = CoquiEngine(model_name="tts_models/en/vctk/vits")
+    # Use a smaller model to avoid long downloads during tests
+    engine = CoquiEngine(model_name="tts_models/en/ljspeech/tacotron2-DDC")
     stream = TextToAudioStream(engine)
 
 


### PR DESCRIPTION
## Summary
- use smaller TTS model
- exit unless `RUN_SPEECH=1`

## Testing
- `pytest -q`
- `python speak.py`

------
https://chatgpt.com/codex/tasks/task_e_68592b71237c8321b3bf47615addfee0